### PR TITLE
Add weekly tracker

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,7 @@
 # Pruebas Codex
 
 Este repositorio está preparado para pruebas con el agente Codex de ChatGPT.
+
+## Weekly Tracker
+
+Abre `index.html` en un navegador para utilizar un sistema de seguimiento semanal. El script guarda el progreso de cada semana en `localStorage` y reinicia los datos cada domingo a las 23:59. También puedes forzar el reinicio introduciendo el PIN `1234`.

--- a/app.js
+++ b/app.js
@@ -1,0 +1,95 @@
+(function () {
+  const PIN = '1234';
+  const WEEK_MS = 7 * 24 * 60 * 60 * 1000;
+  const pointsEl = document.getElementById('points');
+  const tasksEl = document.getElementById('tasks');
+  const messageEl = document.getElementById('message');
+
+  function loadData() {
+    const data = JSON.parse(localStorage.getItem('weeklyData') || '{}');
+    if (!data.startDate) {
+      data.startDate = Date.now();
+      data.points = 0;
+      data.completedTasks = 0;
+      localStorage.setItem('weeklyData', JSON.stringify(data));
+    }
+    return data;
+  }
+
+  function saveData(data) {
+    localStorage.setItem('weeklyData', JSON.stringify(data));
+  }
+
+  function updateView(data) {
+    pointsEl.textContent = data.points;
+    tasksEl.textContent = data.completedTasks;
+  }
+
+  function pushHistory(record) {
+    const history = JSON.parse(localStorage.getItem('history') || '[]');
+    history.push(record);
+    localStorage.setItem('history', JSON.stringify(history));
+  }
+
+  function getNextResetTime(from) {
+    const d = new Date(from);
+    // Set to next Sunday 23:59
+    d.setUTCHours(23, 59, 0, 0);
+    const day = d.getUTCDay();
+    const diff = (7 - day) % 7; // days until Sunday
+    d.setUTCDate(d.getUTCDate() + diff);
+    if (d.getTime() <= from) {
+      d.setUTCDate(d.getUTCDate() + 7);
+    }
+    return d.getTime();
+  }
+
+  function resetWeek(data) {
+    const now = Date.now();
+    pushHistory({
+      weekStart: data.startDate,
+      weekEnd: now,
+      points: data.points,
+      completedTasks: data.completedTasks,
+    });
+    data.startDate = now;
+    data.points = 0;
+    data.completedTasks = 0;
+    data.lastReset = now;
+    saveData(data);
+    updateView(data);
+  }
+
+  function checkReset(data) {
+    const nextReset = getNextResetTime(data.startDate);
+    if (Date.now() >= nextReset) {
+      resetWeek(data);
+    }
+  }
+
+  function tick(data) {
+    checkReset(data);
+  }
+
+  function manualReset(data) {
+    const pinValue = document.getElementById('pin').value;
+    if (pinValue === PIN) {
+      messageEl.textContent = '';
+      resetWeek(data);
+    } else {
+      messageEl.textContent = 'Invalid PIN';
+    }
+  }
+
+  const data = loadData();
+  updateView(data);
+  checkReset(data); // check on load in case we missed
+
+  document.getElementById('manual-reset').addEventListener('click', function () {
+    manualReset(data);
+  });
+
+  setInterval(function () {
+    tick(data);
+  }, 60 * 1000); // check every minute
+})();

--- a/index.html
+++ b/index.html
@@ -1,0 +1,27 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Weekly Tracker</title>
+  <style>
+    body { font-family: Arial, sans-serif; padding: 20px; }
+    label, input, button { margin-top: 10px; display: block; }
+    .error { color: red; }
+  </style>
+</head>
+<body>
+  <h1>Weekly Tracker</h1>
+  <div>
+    <p>Points: <span id="points">0</span></p>
+    <p>Completed Tasks: <span id="tasks">0</span></p>
+  </div>
+  <div>
+    <label for="pin">PIN to reset:</label>
+    <input type="password" id="pin"/>
+    <button id="manual-reset">Manual Reset</button>
+    <p id="message" class="error"></p>
+  </div>
+  <script src="app.js"></script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- add a simple web page to track weekly points and tasks
- implement automatic reset every Sunday at 23:59
- keep a history of weekly records in localStorage
- allow manual reset protected with a PIN
- document how to use the tracker

## Testing
- `npm test` *(fails: cannot find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_686c33324150832a90da20644e3df4d3